### PR TITLE
Added fix to read frame ID from image message header.

### DIFF
--- a/include/apriltags.h
+++ b/include/apriltags.h
@@ -2,7 +2,6 @@ const double SMALL_TAG_SIZE = 0.0358968;
 const double MED_TAG_SIZE = 0.06096;
 const double PAGE_TAG_SIZE = 0.165;
 
-const std::string DEFAULT_TF_FRAME = "/apriltags";
 const std::string DEFAULT_TAG_FAMILY = "Tag36h11";
 const std::string DEFAULT_IMAGE_TOPIC = "image";
 const std::string DEFAULT_CAMERA_INFO_TOPIC = "camera_info";
@@ -33,7 +32,6 @@ std::string tag_family_name_;
 int viewer_;
 double default_tag_size_;
 boost::unordered_map<size_t, double> tag_sizes_;
-std::string frame_;
 bool running_;
 bool has_camera_info_;
 std::string display_type_;

--- a/launch/apriltags.launch
+++ b/launch/apriltags.launch
@@ -5,7 +5,6 @@
   -->
   <node pkg="apriltags" type="apriltags" name="apriltags">
     <param name="~default_tag_size" value="0.037" />
-    <param name="~tf_frame" value="/camera_rgb_optical_frame"/>
 
     <rosparam command="delete" param="tag_data" />
     <rosparam param="tag_data">

--- a/src/apriltags.cpp
+++ b/src/apriltags.cpp
@@ -149,7 +149,7 @@ void ImageCallback(const sensor_msgs::ImageConstPtr& msg)
     detector_->process(subscribed_gray, opticalCenter, detections);
     visualization_msgs::MarkerArray marker_transforms;
     apriltags::AprilTagDetections apriltag_detections;
-    apriltag_detections.header.frame_id = frame_;
+    apriltag_detections.header.frame_id = msg->header.frame_id;
     apriltag_detections.header.stamp = msg->header.stamp;
     
     if(viewer_)
@@ -175,7 +175,7 @@ void ImageCallback(const sensor_msgs::ImageConstPtr& msg)
         cout << tag_size << " " << detections[i].id << endl;
         
         visualization_msgs::Marker marker_transform;
-        marker_transform.header.frame_id = frame_;
+        marker_transform.header.frame_id = msg->header.frame_id;
         marker_transform.header.stamp = msg->header.stamp;
         stringstream convert;
         convert << "tag" << detections[i].id;
@@ -284,7 +284,6 @@ void GetParameterValues()
     node_->param("viewer", viewer_, 0);
     node_->param("tag_family", tag_family_name_, DEFAULT_TAG_FAMILY);
     node_->param("default_tag_size", default_tag_size_, DEFAULT_TAG_SIZE);
-    node_->param("tf_frame", frame_, DEFAULT_TF_FRAME);
     node_->param("display_type", display_type_, DEFAULT_DISPLAY_TYPE);
 
     ROS_INFO("Tag Family: %s", tag_family_name_.c_str());


### PR DESCRIPTION
This PR change the marker publishers to use the frame IDs from the incoming camera frames instead of a rosparam.