### PR TITLE
Added CGAL dependency

### DIFF
--- a/package.xml
+++ b/package.xml
@@ -19,6 +19,7 @@
   <build_depend>eigen</build_depend>
   <build_depend>git</build_depend>
   <build_depend>message_generation</build_depend>
+  <depend>cgal</depend>
   <depend>cv_bridge</depend>
   <depend>geometry_msgs</depend>
   <depend>image_transport</depend>


### PR DESCRIPTION
CGAL is technically an optional dependency. However, building Apriltags without CGAL results in it spamming this warning message to the console:
```
*** WARNING: NEW QUAD ALGORITHM REQUESTED, BUT COMPILED WITHOUT CGAL SUPPORT, FALLING BACK TO OLD ALGORITHM. ***
```